### PR TITLE
Fix error of test's compilation

### DIFF
--- a/include/port/async-pipe.h
+++ b/include/port/async-pipe.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#include <signal.h>
+
 typedef void* async_pipe_t;
 typedef void (*async_pipe_onread)(void* param, int code, int bytes);
 typedef void (*async_pipe_onwrite)(void* param, int code, int bytes);
@@ -24,6 +26,10 @@ int async_pipe_read(async_pipe_t pipe, void* msg, int len, async_pipe_onread cal
 // msg must be valid until callback be called
 // return: 0-success, other-error
 int async_pipe_write(async_pipe_t pipe, const void* msg, int len, async_pipe_onwrite callback, void* param);
+
+static void aio_onread(sigval_t sigval);
+
+static void aio_onwrite(sigval_t sigval);
 
 #ifdef __cplusplus
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,7 +30,7 @@ _SOURCE_FILES += $(ROOT)/source/port/sysvolume.cpp
 _SOURCE_FILES += $(ROOT)/source/string/snprintf.c
 _SOURCE_FILES += $(ROOT)/source/string/strndup.c
 _SOURCE_FILES += ./http-test.c
-_SOURCE_FILES += ./rtsp-test.c 
+_SOURCE_FILES += ./rtsp-test.c
 _SOURCE_FILES += ./sdp-test.c
 SOURCE_FILES := $(filter-out $(_SOURCE_FILES),$(SOURCE_FILES))
 
@@ -46,7 +46,7 @@ else
 LIBPATHS +=
 endif
 
-LIBS = rt pthread dl aio
+LIBS = rt pthread dl aio asan
 
 STATIC_LIBS = $(ROOT)/libhttp/$(BUILD).$(PLATFORM)/libhttp.a
 
@@ -68,7 +68,7 @@ endif
 ifdef RTSP_TEST
 SOURCE_FILES += sdp-test.c
 SOURCE_FILES += rtsp-test.c
-SOURCE_FILES += $(ROOT)/../media-server/librtsp/source/rtsp-header-range.c 
+SOURCE_FILES += $(ROOT)/../media-server/librtsp/source/rtsp-header-range.c
 SOURCE_FILES += $(ROOT)/../media-server/librtsp/source/rtsp-header-rtp-info.c
 SOURCE_FILES += $(ROOT)/../media-server/librtsp/source/rtsp-header-session.c
 SOURCE_FILES += $(ROOT)/../media-server/librtsp/source/rtsp-header-transport.c


### PR DESCRIPTION
Make returned errors of undeclared "aio_write", "aio_read" and "sigval_t" in 'linux-async-pipe.c'. And make RELEASE=1 didn't work without -lasan flag.