### PR TITLE
fix libhls undefined reference

### DIFF
--- a/libhttp/Makefile
+++ b/libhttp/Makefile
@@ -21,6 +21,8 @@ INCLUDES = . \
 SOURCE_PATHS = source
 SOURCE_FILES = $(foreach dir,$(SOURCE_PATHS),$(wildcard $(dir)/*.cpp))
 SOURCE_FILES += $(foreach dir,$(SOURCE_PATHS),$(wildcard $(dir)/*.c))
+SOURCE_FILES += $(ROOT)/source/digest/sha1.c
+SOURCE_FILES += $(ROOT)/source/base64.c
 
 #-----------------------------Library--------------------------------
 #


### PR DESCRIPTION
media-server libhls "undefined reference to "SHA1Input SHA1Result base64_encode" "